### PR TITLE
Revert "chore(deps): update helm release gitea to v8"

### DIFF
--- a/cluster/services/gitea/Chart.yaml
+++ b/cluster/services/gitea/Chart.yaml
@@ -5,5 +5,5 @@ type: application
 version: 0.0.1
 dependencies:
   - name: gitea
-    version: 8.0.2
+    version: 7.0.4
     repository: https://dl.gitea.io/charts/


### PR DESCRIPTION
Reverts clemak27/homelab#495

```
one or more objects failed to apply, reason: StatefulSet.apps "gitea-postgresql" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden (retried 5 times).
```
