### PR TITLE
Revert "chore(deps): update docker.io/homeassistant/home-assistant docker tag to v2024.10"

### DIFF
--- a/cluster/services/home-assistant/values.yaml
+++ b/cluster/services/home-assistant/values.yaml
@@ -6,7 +6,7 @@ controllers:
       main:
         image:
           repository: docker.io/homeassistant/home-assistant
-          tag: "2024.10"
+          tag: "2024.9"
         env:
           TZ: Europe/Vienna
 


### PR DESCRIPTION
Reverts clemak27/homelab#1041

somehow mqtt entities stopped working? https://github.com/home-assistant/core/issues/128653